### PR TITLE
Add client-side filtering for interest levels to card columns.

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
-import { Briefcase, Plus } from "lucide-react";
+import { Briefcase, Plus, Filter } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,6 +13,13 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 
@@ -35,21 +42,52 @@ function KanbanColumn({
   prospects: Prospect[];
   isLoading: boolean;
 }) {
+  const [interestFilter, setInterestFilter] = useState<string>("All");
+
+  const filteredProspects = interestFilter === "All"
+    ? prospects
+    : prospects.filter((p) => p.interestLevel === interestFilter);
+
+  const statusSlug = status.replace(/\s+/g, "-").toLowerCase();
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
-      data-testid={`column-${status.replace(/\s+/g, "-").toLowerCase()}`}
+      data-testid={`column-${statusSlug}`}
     >
-      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border/50">
-        <div className={`w-2 h-2 rounded-full ${columnColors[status] || "bg-gray-400"}`} />
-        <h3 className="text-sm font-semibold truncate">{status}</h3>
-        <Badge
-          variant="secondary"
-          className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
-          data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
-        >
-          {prospects.length}
-        </Badge>
+      <div className="flex flex-col gap-1.5 px-3 py-2.5 border-b border-border/50">
+        <div className="flex items-center gap-2">
+          <div className={`w-2 h-2 rounded-full ${columnColors[status] || "bg-gray-400"}`} />
+          <h3 className="text-sm font-semibold truncate">{status}</h3>
+          <Badge
+            variant="secondary"
+            className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
+            data-testid={`badge-count-${statusSlug}`}
+          >
+            {filteredProspects.length}
+          </Badge>
+        </div>
+        <Select value={interestFilter} onValueChange={setInterestFilter}>
+          <SelectTrigger
+            className="h-7 text-xs w-full"
+            data-testid={`filter-interest-${statusSlug}`}
+          >
+            <Filter className="w-3 h-3 mr-1 shrink-0" />
+            <SelectValue placeholder="Filter by interest" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="All" data-testid={`filter-option-all-${statusSlug}`}>All Levels</SelectItem>
+            {INTEREST_LEVELS.map((level) => (
+              <SelectItem
+                key={level}
+                value={level}
+                data-testid={`filter-option-${level.toLowerCase()}-${statusSlug}`}
+              >
+                {level}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
@@ -58,12 +96,12 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
+          ) : filteredProspects.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${statusSlug}`}>
               <p className="text-xs text-muted-foreground">No prospects</p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}


### PR DESCRIPTION
Implement a client-side filtering system in `home.tsx` allowing users to filter prospects by 'Interest Level' (Low, Medium, High, All) via independent dropdown menus in each Kanban column, updating card counts and visibility without server interaction.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 58d66ecf-3f30-4ed3-a1fd-6d9cafc5fcfa
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 4aec024a-e4d0-47c9-9fcc-1cd3951d9017
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/cf30b1be-4962-45c0-a717-6d07afe77312/58d66ecf-3f30-4ed3-a1fd-6d9cafc5fcfa/Pz1hc4w
Replit-Helium-Checkpoint-Created: true